### PR TITLE
Add stage-change notifications for favorited bills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ fastlane/test_output
 iOSInjectionProject/
 
 # End of https://www.toptal.com/developers/gitignore/api/swift
+
+.superpowers/

--- a/TodayBill.xcodeproj/project.pbxproj
+++ b/TodayBill.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		1DD96EEE2D4E6AF4005FD3AF /* TimelineItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD96EED2D4E6AF4005FD3AF /* TimelineItemView.swift */; };
 		1DDB23322DBBADE600490A1B /* BillEntity.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1DDB23302DBBADE600490A1B /* BillEntity.xcdatamodeld */; };
 		1DE634B62D698574007716C8 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE634B52D698574007716C8 /* Theme.swift */; };
+		634D012B8A6592A994EA3AE6 /* StageChangeNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D85FC115A3484901EA025E /* StageChangeNotifier.swift */; };
+		E921D2057F4A1D9CC250AABE /* StageChangeNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAD0E70A0F78EA233046B9E /* StageChangeNotifierTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -92,6 +94,8 @@
 		1DD96EED2D4E6AF4005FD3AF /* TimelineItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemView.swift; sourceTree = "<group>"; };
 		1DDB23312DBBADE600490A1B /* BillEntity.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = BillEntity.xcdatamodel; sourceTree = "<group>"; };
 		1DE634B52D698574007716C8 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		28D85FC115A3484901EA025E /* StageChangeNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChangeNotifier.swift; sourceTree = "<group>"; };
+		6DAD0E70A0F78EA233046B9E /* StageChangeNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChangeNotifierTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +122,7 @@
 			isa = PBXGroup;
 			children = (
 				A1B2C3D4E5F6012345678901 /* CoreDataManagerTests.swift */,
+				6DAD0E70A0F78EA233046B9E /* StageChangeNotifierTests.swift */,
 			);
 			path = TodayBillTests;
 			sourceTree = "<group>";
@@ -238,6 +243,7 @@
 				1D672B7F2D422E85000DD244 /* AppInitializer.swift */,
 				1D30EB182B0C3156006C1588 /* AppDelegate.swift */,
 				1D30EB1A2B0C3156006C1588 /* SceneDelegate.swift */,
+				28D85FC115A3484901EA025E /* StageChangeNotifier.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -418,6 +424,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A1B2C3D4E5F6012345678902 /* CoreDataManagerTests.swift in Sources */,
+				E921D2057F4A1D9CC250AABE /* StageChangeNotifierTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -459,6 +466,7 @@
 				1DE634B62D698574007716C8 /* Theme.swift in Sources */,
 				1D69B1A42D43501D00EB70F0 /* SearchViewController.swift in Sources */,
 				1D6476B92D45283B002A61B3 /* ListViewController.swift in Sources */,
+				634D012B8A6592A994EA3AE6 /* StageChangeNotifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TodayBill/Core/AppDelegate.swift
+++ b/TodayBill/Core/AppDelegate.swift
@@ -49,12 +49,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func handleStageCheck(task: BGAppRefreshTask) {
         scheduleStageCheckIfNeeded()
 
+        let lock = NSLock()
+        var isFinished = false
+        func finish(success: Bool) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !isFinished else { return }
+            isFinished = true
+            task.setTaskCompleted(success: success)
+        }
+
         task.expirationHandler = {
-            task.setTaskCompleted(success: false)
+            finish(success: false)
         }
 
         StageChangeNotifier.run {
-            task.setTaskCompleted(success: true)
+            finish(success: true)
         }
     }
 

--- a/TodayBill/Core/AppDelegate.swift
+++ b/TodayBill/Core/AppDelegate.swift
@@ -21,6 +21,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             self.handleStageCheck(task: task as! BGAppRefreshTask)
         }
         UNUserNotificationCenter.current().delegate = self
+
+        // Scene-based apps never receive `applicationDidEnterBackground(_:)`, but UIKit
+        // still posts `didEnterBackgroundNotification`, so schedule from there instead.
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.scheduleStageCheckIfNeeded()
+        }
+
+        scheduleStageCheckIfNeeded()
+        requestNotificationPermissionIfNeeded()
         return true
     }
 
@@ -44,6 +57,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let request = BGAppRefreshTaskRequest(identifier: Self.stageCheckTaskIdentifier)
         request.earliestBeginDate = Date(timeIntervalSinceNow: 6 * 60 * 60)
         try? BGTaskScheduler.shared.submit(request)
+    }
+
+    /// Covers users who already had favorites before this feature shipped — the
+    /// first-favorite prompt in `BillsRepository.toggleFavorite` only fires on a 0→1 transition.
+    private func requestNotificationPermissionIfNeeded() {
+        guard !CoreDataManager.shared.fetchFavoriteSnapshots().isEmpty else { return }
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            guard settings.authorizationStatus == .notDetermined else { return }
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, _ in }
+        }
     }
 
     private func handleStageCheck(task: BGAppRefreshTask) {
@@ -103,10 +127,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     private func selectStarTab() {
-        guard let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-              let tabBarController = windowScene.windows.first?.rootViewController as? MainTabBarViewController else {
-            return
-        }
-        tabBarController.selectTab(at: 2) // 추적 tab — see AppInitializer.swift:26-30
+        // Tapping a digest is a cold-launch/resume path, so the scene may still be
+        // `.foregroundInactive` here — look the tab bar up without depending on activation state.
+        let tabBarController = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .compactMap { $0.rootViewController as? MainTabBarViewController }
+            .first
+        tabBarController?.selectTab(at: 2) // 추적 tab — see AppInitializer.swift:26-30
     }
 }

--- a/TodayBill/Core/AppDelegate.swift
+++ b/TodayBill/Core/AppDelegate.swift
@@ -90,4 +90,23 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) {
         completionHandler([.banner, .sound])
     }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if response.notification.request.identifier == StageChangeNotifier.notificationRequestIdentifier {
+            selectStarTab()
+        }
+        completionHandler()
+    }
+
+    private func selectStarTab() {
+        guard let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+              let tabBarController = windowScene.windows.first?.rootViewController as? MainTabBarViewController else {
+            return
+        }
+        tabBarController.selectTab(at: 2) // 추적 tab — see AppInitializer.swift:26-30
+    }
 }

--- a/TodayBill/Core/AppDelegate.swift
+++ b/TodayBill/Core/AppDelegate.swift
@@ -6,42 +6,78 @@
 //
 
 import UIKit
+import BackgroundTasks
+import UserNotifications
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
+
+    static let stageCheckTaskIdentifier = "Test.TodayBill.stagecheck"
+
     var window: UIWindow?
-    
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.stageCheckTaskIdentifier, using: nil) { task in
+            self.handleStageCheck(task: task as! BGAppRefreshTask)
+        }
+        UNUserNotificationCenter.current().delegate = self
         return true
     }
-    
+
     func applicationDidEnterBackground(_ application: UIApplication) {
         saveFavoriteData()
+        scheduleStageCheckIfNeeded()
     }
-    
+
     func applicationWillTerminate(_ application: UIApplication) {
         saveFavoriteData()
     }
-    
+
     private func saveFavoriteData() {
         let starredBills = StarBillManager.shared.loadStarredBills()
-        StarBillManager.shared.saveStarredBills(starredBills)        
+        StarBillManager.shared.saveStarredBills(starredBills)
     }
-    
+
+    private func scheduleStageCheckIfNeeded() {
+        guard !CoreDataManager.shared.fetchFavoriteSnapshots().isEmpty else { return }
+
+        let request = BGAppRefreshTaskRequest(identifier: Self.stageCheckTaskIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 6 * 60 * 60)
+        try? BGTaskScheduler.shared.submit(request)
+    }
+
+    private func handleStageCheck(task: BGAppRefreshTask) {
+        scheduleStageCheckIfNeeded()
+
+        task.expirationHandler = {
+            task.setTaskCompleted(success: false)
+        }
+
+        StageChangeNotifier.run {
+            task.setTaskCompleted(success: true)
+        }
+    }
+
     // MARK: UISceneSession Lifecycle
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-    
+
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-    
-    
 }
 
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+}

--- a/TodayBill/Core/StageChangeNotifier.swift
+++ b/TodayBill/Core/StageChangeNotifier.swift
@@ -37,17 +37,26 @@ enum StageChangeNotifier {
                 return
             }
 
-            center.add(UNNotificationRequest(
-                identifier: notificationRequestIdentifier,
-                content: makeContent(for: toNotify),
-                trigger: nil
-            ))
+            // Only mark a change as announced if it can actually be delivered — otherwise an
+            // unauthorized user would silently lose the change even after enabling notifications.
+            center.getNotificationSettings { settings in
+                guard settings.authorizationStatus == .authorized else {
+                    completion()
+                    return
+                }
 
-            var updatedKeys = notifiedKeys
-            toNotify.forEach { updatedKeys[$0.billID] = $0.stageKey }
-            defaults.set(updatedKeys, forKey: notifiedStageKeysDefaultsKey)
+                center.add(UNNotificationRequest(
+                    identifier: notificationRequestIdentifier,
+                    content: makeContent(for: toNotify),
+                    trigger: nil
+                ))
 
-            completion()
+                var updatedKeys = notifiedKeys
+                toNotify.forEach { updatedKeys[$0.billID] = $0.stageKey }
+                defaults.set(updatedKeys, forKey: notifiedStageKeysDefaultsKey)
+
+                completion()
+            }
         }
     }
 

--- a/TodayBill/Core/StageChangeNotifier.swift
+++ b/TodayBill/Core/StageChangeNotifier.swift
@@ -1,0 +1,73 @@
+//
+//  StageChangeNotifier.swift
+//  TodayBill
+//
+
+import Foundation
+import UserNotifications
+
+enum StageChangeNotifier {
+    static let notifiedStageKeysDefaultsKey = "StageChangeNotifier.notifiedStageKeys"
+    static let notificationRequestIdentifier = "stageChangeDigest"
+
+    /// Favorited bills whose stage changed since the last time this exact
+    /// change was announced. Pure function — no CoreData/UserDefaults/UNUserNotificationCenter access.
+    static func billsToNotify(from snapshots: [BillSnapshot], notifiedStageKeys: [String: String]) -> [BillSnapshot] {
+        snapshots.filter { $0.hasUnseenStageChange && notifiedStageKeys[$0.billID] != $0.stageKey }
+    }
+
+    /// Refreshes favorited bills, posts a digest notification if anything changed, and
+    /// records what was announced so the same change isn't re-sent next time.
+    static func run(
+        repository: BillRepositoryProtocol = BillRepository.shared,
+        defaults: UserDefaults = .standard,
+        center: UNUserNotificationCenter = .current(),
+        completion: @escaping () -> Void = {}
+    ) {
+        repository.refreshFavoriteSnapshots { result in
+            guard case .success(let snapshots) = result, !snapshots.isEmpty else {
+                completion()
+                return
+            }
+
+            let notifiedKeys = defaults.dictionary(forKey: notifiedStageKeysDefaultsKey) as? [String: String] ?? [:]
+            let toNotify = billsToNotify(from: snapshots, notifiedStageKeys: notifiedKeys)
+            guard !toNotify.isEmpty else {
+                completion()
+                return
+            }
+
+            center.add(UNNotificationRequest(
+                identifier: notificationRequestIdentifier,
+                content: makeContent(for: toNotify),
+                trigger: nil
+            ))
+
+            var updatedKeys = notifiedKeys
+            toNotify.forEach { updatedKeys[$0.billID] = $0.stageKey }
+            defaults.set(updatedKeys, forKey: notifiedStageKeysDefaultsKey)
+
+            completion()
+        }
+    }
+
+    /// Call when a bill is un-favorited so a stale "already notified" entry
+    /// doesn't linger if the same bill is favorited again later.
+    static func clearNotified(billID: String, defaults: UserDefaults = .standard) {
+        var stored = defaults.dictionary(forKey: notifiedStageKeysDefaultsKey) as? [String: String] ?? [:]
+        stored.removeValue(forKey: billID)
+        defaults.set(stored, forKey: notifiedStageKeysDefaultsKey)
+    }
+
+    private static func makeContent(for bills: [BillSnapshot]) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "관심 법안 업데이트"
+        content.sound = .default
+        if bills.count == 1 {
+            content.body = "\(bills[0].title)의 진행 상태가 바뀌었어요"
+        } else {
+            content.body = "\(bills[0].title) 등 \(bills.count)개 법안의 진행 상태가 바뀌었어요"
+        }
+        return content
+    }
+}

--- a/TodayBill/Info.plist
+++ b/TodayBill/Info.plist
@@ -32,5 +32,13 @@
 	<string>7e233d4fbea04f17b0e3218ccb604750</string>
 	<key>LawInfoServiceKey</key>
 	<string>$(LAW_INFO_API_KEY)</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>Test.TodayBill.stagecheck</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
 </dict>
 </plist>

--- a/TodayBill/Model/Repository/BillsRepository.swift
+++ b/TodayBill/Model/Repository/BillsRepository.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UserNotifications
 
 enum BillsRepositoryError: Error {
     case dateConversionFailed
@@ -240,8 +241,12 @@ final class BillRepository: BillRepositoryProtocol {
 
         if snapshot.isFavorite {
             StarBillManager.shared.addBillToStarred(snapshot.toStarredBill())
+            if coreDataManager.fetchFavoriteSnapshots().count == 1 {
+                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, _ in }
+            }
         } else {
             StarBillManager.shared.removeBillFromStarred(by: id)
+            StageChangeNotifier.clearNotified(billID: id)
         }
         completion(.success(snapshot))
     }

--- a/TodayBill/View/Tabbar/MainTabBarViewController.swift
+++ b/TodayBill/View/Tabbar/MainTabBarViewController.swift
@@ -70,7 +70,7 @@ final class MainTabBarViewController: UIViewController {
         tabBarHeightConstraint?.constant = tabBarContentHeight + view.safeAreaInsets.bottom
     }
     
-    private func selectTab(at index: Int) {
+    func selectTab(at index: Int) {
         guard index >= 0 && index < viewControllers.count else { return }
         
         let selectedViewController = viewControllers[index]

--- a/TodayBillTests/StageChangeNotifierTests.swift
+++ b/TodayBillTests/StageChangeNotifierTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import TodayBill
+
+final class StageChangeNotifierTests: XCTestCase {
+    func testBillsToNotifyIncludesOnlyUnnotifiedUnseenChanges() {
+        let changed = makeSnapshot(id: "A1", committeeDate: "2025-02-01", lastSeenStageKey: "committee|2025-01-01")
+        let unchanged = makeSnapshot(id: "A2", committeeDate: "2025-01-01", lastSeenStageKey: "committee|2025-01-01")
+        let alreadyNotified = makeSnapshot(id: "A3", committeeDate: "2025-03-01", lastSeenStageKey: "committee|2025-01-01")
+
+        let result = StageChangeNotifier.billsToNotify(
+            from: [changed, unchanged, alreadyNotified],
+            notifiedStageKeys: ["A3": alreadyNotified.stageKey]
+        )
+
+        XCTAssertEqual(result.map(\.billID), ["A1"])
+    }
+
+    func testBillsToNotifyIgnoresNonFavorites() {
+        let nonFavorite = makeSnapshot(id: "B1", committeeDate: "2025-02-01", lastSeenStageKey: "committee|2025-01-01", isFavorite: false)
+
+        let result = StageChangeNotifier.billsToNotify(from: [nonFavorite], notifiedStageKeys: [:])
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    private func makeSnapshot(
+        id: String,
+        committeeDate: String,
+        lastSeenStageKey: String?,
+        isFavorite: Bool = true
+    ) -> BillSnapshot {
+        BillSnapshot(
+            billID: id,
+            age: 22,
+            title: "테스트 법안 \(id)",
+            committeeDate: committeeDate,
+            isFavorite: isFavorite,
+            lastSeenStageKey: lastSeenStageKey
+        )
+    }
+}

--- a/TodayBillTests/StageChangeNotifierTests.swift
+++ b/TodayBillTests/StageChangeNotifierTests.swift
@@ -23,6 +23,14 @@ final class StageChangeNotifierTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    func testBillsToNotifyExcludesNeverSeenBills() {
+        let neverSeen = makeSnapshot(id: "C1", committeeDate: "2025-02-01", lastSeenStageKey: nil)
+
+        let result = StageChangeNotifier.billsToNotify(from: [neverSeen], notifiedStageKeys: [:])
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
     private func makeSnapshot(
         id: String,
         committeeDate: String,


### PR DESCRIPTION
## Summary
- Add `StageChangeNotifier`: pure filter for favorited bills with an unannounced stage change, plus digest-notification orchestration backed by UserDefaults (no CoreData migration)
- Schedule a `BGAppRefreshTask` to check favorited bills' status periodically in the background
- Request notification permission on a user's first favorite, and at launch for users who already had favorites
- Route a tapped notification to the 추적 tab
- Fix a critical bug found in final review: this app uses the UIScene lifecycle, so `AppDelegate.applicationDidEnterBackground(_:)` is never called by UIKit — background scheduling now hooks `UIApplication.didEnterBackgroundNotification` instead, which is actually posted for scene-based apps
- Also fixed in final review: a stage change could be marked "announced" even when never delivered (not authorized), and notification-tap routing could silently no-op on the cold-launch path that matters most

## Test plan
- [x] Full test suite: 22/22 passing (19 pre-existing + 3 new `StageChangeNotifierTests`)
- [x] Build succeeds (TodayBill scheme)
- [ ] Manual: background task fires via LLDB debug trigger and posts a digest when a favorited bill's stage actually changed
- [ ] Manual: notification permission prompts once on first favorite (and once at launch for pre-existing favorites, if not yet determined)
- [ ] Manual: tapping the notification opens the app on the 추적 tab