### PR TITLE
Add bill vote summary API

### DIFF
--- a/TodayBill/Model/Data/Bills.swift
+++ b/TodayBill/Model/Data/Bills.swift
@@ -102,6 +102,66 @@ struct FavoriteInfo: Codable {
     var isFavorite: Bool
 }
 
+struct BillVoteSummary: Codable, Equatable {
+    let billID: String
+    let processedDate: String?
+    let result: String?
+    let memberTotalCount: Int
+    let voteTotalCount: Int
+    let yesCount: Int
+    let noCount: Int
+    let blankCount: Int
+
+    var absentCount: Int {
+        max(memberTotalCount - voteTotalCount, 0)
+    }
+
+    var hasVotes: Bool {
+        voteTotalCount > 0
+    }
+}
+
+struct BillVoteResponse: Codable {
+    let ncocpgfiaoituanbr: [BillVoteResponseSection]
+}
+
+struct BillVoteResponseSection: Codable {
+    let head: [Head]?
+    let row: [BillVoteRow]?
+}
+
+struct BillVoteRow: Codable {
+    let BILL_ID: String
+    let PROC_DT: String?
+    let PROC_RESULT_CD: String?
+    let MEMBER_TCNT: String?
+    let VOTE_TCNT: String?
+    let YES_TCNT: String?
+    let NO_TCNT: String?
+    let BLANK_TCNT: String?
+
+    var summary: BillVoteSummary {
+        BillVoteSummary(
+            billID: BILL_ID,
+            processedDate: BillSnapshot.nonEmpty(PROC_DT),
+            result: BillSnapshot.nonEmpty(PROC_RESULT_CD),
+            memberTotalCount: Self.intValue(MEMBER_TCNT),
+            voteTotalCount: Self.intValue(VOTE_TCNT),
+            yesCount: Self.intValue(YES_TCNT),
+            noCount: Self.intValue(NO_TCNT),
+            blankCount: Self.intValue(BLANK_TCNT)
+        )
+    }
+
+    private static func intValue(_ value: String?) -> Int {
+        guard let value else { return 0 }
+        let digitsOnly = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .filter { $0.isNumber }
+        return Int(String(digitsOnly)) ?? 0
+    }
+}
+
 extension Row {
     func toBillEntity(context: NSManagedObjectContext) -> BillEntity {
         let entity = BillEntity(context: context)

--- a/TodayBill/Model/Repository/BillsRepository.swift
+++ b/TodayBill/Model/Repository/BillsRepository.swift
@@ -25,6 +25,7 @@ protocol BillRepositoryProtocol {
     func refreshFavoriteSnapshots(completion: @escaping (Result<[BillSnapshot], Error>) -> Void)
     func markStageSeen(id: String)
     func fetchSummary(for snapshot: BillSnapshot, completion: @escaping (Result<BillSnapshot, Error>) -> Void)
+    func fetchVoteSummary(billID: String, age: Int, completion: @escaping (Result<BillVoteSummary?, Error>) -> Void)
     func cachedSnapshot(id: String) -> BillSnapshot?
 }
 
@@ -55,6 +56,7 @@ final class BillRepository: BillRepositoryProtocol {
     static let shared = BillRepository()
 
     private let apiClient: OpenAssemblyAPIClient
+    private let voteAPIClient: OpenAssemblyVoteAPIClient
     private let summaryClient: AssemblySummaryClient
     private let lawInfoClient: LawInfoAPIClient
     private let coreDataManager: CoreDataManager
@@ -62,12 +64,14 @@ final class BillRepository: BillRepositoryProtocol {
 
     init(
         apiClient: OpenAssemblyAPIClient = .shared,
+        voteAPIClient: OpenAssemblyVoteAPIClient = .shared,
         summaryClient: AssemblySummaryClient = AssemblySummaryClient(),
         lawInfoClient: LawInfoAPIClient = .shared,
         coreDataManager: CoreDataManager = .shared,
         dashboardCache: HomeDashboardCache = HomeDashboardCache()
     ) {
         self.apiClient = apiClient
+        self.voteAPIClient = voteAPIClient
         self.summaryClient = summaryClient
         self.lawInfoClient = lawInfoClient
         self.coreDataManager = coreDataManager
@@ -309,6 +313,14 @@ final class BillRepository: BillRepositoryProtocol {
                 completion(.failure(error))
             }
         }
+    }
+
+    func fetchVoteSummary(
+        billID: String,
+        age: Int,
+        completion: @escaping (Result<BillVoteSummary?, Error>) -> Void
+    ) {
+        voteAPIClient.fetchVoteSummary(billID: billID, age: age, completion: completion)
     }
 
     func cachedSnapshot(id: String) -> BillSnapshot? {
@@ -565,6 +577,7 @@ final class DetailViewModel {
     private var currentSnapshot: BillSnapshot?
     var onStateChange: ((ViewState<BillSnapshot>) -> Void)?
     var onSummaryUpdate: ((BillSnapshot) -> Void)?
+    var onVoteSummaryUpdate: ((BillVoteSummary?) -> Void)?
 
     init(billID: String, age: Int, repository: BillRepositoryProtocol = BillRepository.shared) {
         self.billID = billID
@@ -591,6 +604,7 @@ final class DetailViewModel {
                     self.currentSnapshot = visibleSnapshot
                     self.onStateChange?(.loaded(visibleSnapshot))
                     self.refreshSummaryIfNeeded(snapshot: visibleSnapshot)
+                    self.refreshVoteSummary(snapshot: visibleSnapshot)
                 case .failure:
                     self.onStateChange?(.error("법안 정보를 불러오는 데 실패했습니다."))
                 }
@@ -635,6 +649,20 @@ final class DetailViewModel {
                 if case let .success(updated) = result {
                     self.currentSnapshot = updated
                     self.onSummaryUpdate?(updated)
+                }
+            }
+        }
+    }
+
+    private func refreshVoteSummary(snapshot: BillSnapshot) {
+        repository.fetchVoteSummary(billID: snapshot.billID, age: snapshot.age) { [weak self] result in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let summary):
+                    self.onVoteSummaryUpdate?(summary)
+                case .failure:
+                    self.onVoteSummaryUpdate?(nil)
                 }
             }
         }

--- a/TodayBill/Model/Service/BillsService.swift
+++ b/TodayBill/Model/Service/BillsService.swift
@@ -121,6 +121,78 @@ final class OpenAssemblyAPIClient {
     }
 }
 
+final class OpenAssemblyVoteAPIClient {
+    static let shared = OpenAssemblyVoteAPIClient()
+
+    private let baseURL = "https://open.assembly.go.kr/portal/openapi/ncocpgfiaoituanbr"
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetchVoteSummary(
+        billID: String,
+        age: Int,
+        completion: @escaping (Result<BillVoteSummary?, Error>) -> Void
+    ) {
+        guard var urlComponents = URLComponents(string: baseURL) else {
+            completion(.failure(OpenAssemblyAPIClientError.invalidURL))
+            return
+        }
+
+        guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "serviceKey") as? String else {
+            completion(.failure(OpenAssemblyAPIClientError.missingAPIKey))
+            return
+        }
+
+        urlComponents.queryItems = [
+            URLQueryItem(name: "Key", value: apiKey),
+            URLQueryItem(name: "Type", value: "json"),
+            URLQueryItem(name: "pIndex", value: "1"),
+            URLQueryItem(name: "pSize", value: "1"),
+            URLQueryItem(name: "AGE", value: "\(age)"),
+            URLQueryItem(name: "BILL_ID", value: billID)
+        ]
+
+        guard let url = urlComponents.url else {
+            completion(.failure(OpenAssemblyAPIClientError.invalidURL))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(OpenAssemblyAPIClient.userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("ko-KR,ko;q=0.9,en-US;q=0.8", forHTTPHeaderField: "Accept-Language")
+        request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+
+        session.dataTask(with: request) { data, response, error in
+            if let error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode),
+                  let data else {
+                completion(.failure(OpenAssemblyAPIClientError.invalidResponse))
+                return
+            }
+
+            do {
+                let decodedResponse = try JSONDecoder().decode(BillVoteResponse.self, from: data)
+                let summary = decodedResponse.ncocpgfiaoituanbr
+                    .compactMap { $0.row }
+                    .flatMap { $0 }
+                    .first?
+                    .summary
+                completion(.success(summary))
+            } catch {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+}
+
 enum LawInfoAPIClientError: LocalizedError {
     case missingAPIKey
     case invalidURL

--- a/TodayBill/View/Detail/DetailView.swift
+++ b/TodayBill/View/Detail/DetailView.swift
@@ -177,6 +177,8 @@ final class DetailView: UIView {
         return view
     }()
 
+    private let voteSummaryView = DetailVoteSummaryView()
+
     private let proposalReasonTitleLabel = DetailView.makeSectionTitleLabel(text: "제안 이유")
 
     var proposalReasonExpandableView: ExpandableLabelView = {
@@ -263,6 +265,9 @@ final class DetailView: UIView {
         timelineStack.spacing = 10
         mainStackView.addArrangedSubview(timelineStack)
 
+        voteSummaryView.isHidden = true
+        mainStackView.addArrangedSubview(voteSummaryView)
+
         let proposalReasonStack = UIStackView(arrangedSubviews: [proposalReasonTitleLabel, proposalReasonExpandableView])
         proposalReasonStack.axis = .vertical
         proposalReasonStack.spacing = 10
@@ -348,6 +353,16 @@ final class DetailView: UIView {
         keyContentLabel.attributedText = makeBodyText(from: keyText, isPlaceholder: keyText == "요약 준비 중")
 
         configureDetailLink(url: validatedDetailURL(from: snapshot.detailLink))
+    }
+
+    func updateVoteSummary(_ summary: BillVoteSummary?) {
+        guard let summary, summary.hasVotes else {
+            voteSummaryView.isHidden = true
+            return
+        }
+
+        voteSummaryView.isHidden = false
+        voteSummaryView.configure(with: summary)
     }
 
     func showLoading(_ message: String) {
@@ -495,6 +510,171 @@ final class DetailView: UIView {
         label.textColor = Theme.textColor
         label.numberOfLines = 1
         return label
+    }
+}
+
+private final class DetailVoteSummaryView: UIView {
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "본회의 표결 결과"
+        label.font = Theme.Font.sectionTitle
+        label.textColor = Theme.textColor
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private let resultLabel: UILabel = {
+        let label = UILabel()
+        label.font = Theme.Font.metaTextStrong
+        label.textColor = .systemGreen
+        return label
+    }()
+
+    private let countLabel: UILabel = {
+        let label = UILabel()
+        label.font = Theme.Font.heroTitle
+        label.textColor = Theme.textColor
+        return label
+    }()
+
+    private let metaLabel: UILabel = {
+        let label = UILabel()
+        label.font = Theme.Font.metaText
+        label.textColor = Theme.emptyLabelTextColor
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private let barsStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 8
+        return stack
+    }()
+
+    private let yesRow = VoteCountRow(title: "찬성", color: .systemGreen)
+    private let noRow = VoteCountRow(title: "반대", color: .systemRed)
+    private let blankRow = VoteCountRow(title: "기권", color: .systemGray)
+    private let absentRow = VoteCountRow(title: "불참", color: .systemGray3)
+
+    private let contentStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        backgroundColor = Theme.cellBackgroundColor
+        layer.cornerRadius = Theme.Radius.medium
+        layer.masksToBounds = true
+
+        addSubview(contentStackView)
+
+        let headerStack = UIStackView(arrangedSubviews: [titleLabel, resultLabel])
+        headerStack.axis = .horizontal
+        headerStack.alignment = .firstBaseline
+        headerStack.spacing = 8
+
+        barsStackView.addArrangedSubview(yesRow)
+        barsStackView.addArrangedSubview(noRow)
+        barsStackView.addArrangedSubview(blankRow)
+        barsStackView.addArrangedSubview(absentRow)
+
+        contentStackView.addArrangedSubview(headerStack)
+        contentStackView.addArrangedSubview(countLabel)
+        contentStackView.addArrangedSubview(metaLabel)
+        contentStackView.addArrangedSubview(barsStackView)
+
+        NSLayoutConstraint.activate([
+            contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            contentStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            contentStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16)
+        ])
+    }
+
+    func configure(with summary: BillVoteSummary) {
+        resultLabel.text = summary.result
+        resultLabel.isHidden = BillSnapshot.nonEmpty(summary.result) == nil
+        countLabel.text = "\(summary.yesCount)"
+
+        let dateText = BillSnapshot.nonEmpty(summary.processedDate)
+            .map { " · \($0)" } ?? ""
+        metaLabel.text = "재적 \(summary.memberTotalCount)명 · 투표 \(summary.voteTotalCount)명\(dateText)"
+
+        let denominator = max(summary.memberTotalCount, summary.voteTotalCount, 1)
+        yesRow.configure(count: summary.yesCount, denominator: denominator)
+        noRow.configure(count: summary.noCount, denominator: denominator)
+        blankRow.configure(count: summary.blankCount, denominator: denominator)
+        absentRow.configure(count: summary.absentCount, denominator: denominator)
+    }
+}
+
+private final class VoteCountRow: UIView {
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = Theme.Font.metaText
+        label.textColor = Theme.emptyLabelTextColor
+        return label
+    }()
+
+    private let countLabel: UILabel = {
+        let label = UILabel()
+        label.font = Theme.Font.metaTextStrong
+        label.textColor = Theme.textColor
+        label.textAlignment = .right
+        return label
+    }()
+
+    private let progressView = UIProgressView(progressViewStyle: .bar)
+
+    init(title: String, color: UIColor) {
+        super.init(frame: .zero)
+        titleLabel.text = title
+        progressView.progressTintColor = color
+        progressView.trackTintColor = Theme.separator
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        let labelStack = UIStackView(arrangedSubviews: [titleLabel, countLabel])
+        labelStack.axis = .horizontal
+        labelStack.spacing = 8
+
+        let stack = UIStackView(arrangedSubviews: [labelStack, progressView])
+        stack.axis = .vertical
+        stack.spacing = 5
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            progressView.heightAnchor.constraint(equalToConstant: 4)
+        ])
+    }
+
+    func configure(count: Int, denominator: Int) {
+        countLabel.text = "\(count)"
+        progressView.setProgress(Float(count) / Float(max(denominator, 1)), animated: false)
     }
 }
 

--- a/TodayBill/View/Detail/DetailViewController.swift
+++ b/TodayBill/View/Detail/DetailViewController.swift
@@ -77,6 +77,10 @@ final class DetailViewController: UIViewController {
             self?.currentSnapshot = snapshot
             self?.render(snapshot: snapshot)
         }
+
+        viewModel.onVoteSummaryUpdate = { [weak self] summary in
+            self?.contentView.updateVoteSummary(summary)
+        }
     }
 
     private func render(snapshot: BillSnapshot) {

--- a/TodayBillTests/CoreDataManagerTests.swift
+++ b/TodayBillTests/CoreDataManagerTests.swift
@@ -504,6 +504,10 @@ private final class MockBillRepository: BillRepositoryProtocol {
         completion(.failure(BillsRepositoryError.missingSnapshot))
     }
 
+    func fetchVoteSummary(billID: String, age: Int, completion: @escaping (Result<BillVoteSummary?, Error>) -> Void) {
+        completion(.success(nil))
+    }
+
     func cachedSnapshot(id: String) -> BillSnapshot? {
         nil
     }


### PR DESCRIPTION
## Summary
- Add an OpenAssembly vote summary client for `ncocpgfiaoituanbr`
- Decode per-bill plenary vote totals: members, total votes, yes, no, blank, and inferred absent count
- Load vote summaries from the detail view model and render a hidden-when-empty vote result card in bill detail
- Update the repository test mock for the expanded protocol

## Notes
- This PR intentionally does not include the design PDFs or temporary render files.
- "Together reviewed bills" is not implemented here because the official API does not expose a direct relationship for that concept.

## Validation
- Built TodayBill for iOS Simulator successfully
- Ran the full simulator test suite: 22 passed, 0 failed
- Verified the vote API returns expected fields against a known sample bill
